### PR TITLE
Also provide gpgkeys on v2 API (symlink v2 -> v1)

### DIFF
--- a/export_gpg_keys.py
+++ b/export_gpg_keys.py
@@ -39,6 +39,13 @@ def store_gpg(gpg_result,targetdir,plain):
             os.makedirs(targetdir + "/katello/api")
         if not os.path.exists(targetdir + "/katello/api/repositories"):
             os.makedirs(targetdir + "/katello/api/repositories")
+        """
+        Symlink v2 API with v1
+        """
+        if not os.path.exists(targetdir + "/katello/api/v2"):
+            os.makedirs(targetdir + "/katello/api/v2")
+        if not os.path.islink(targetdir + "/katello/api/v2/repositories"):
+            os.symlink("../repositories", targetdir + "/katello/api/v2/repositories")
         fakedir = targetdir + "/katello/api/repositories/"
     for gpg in gpg_result:
         for repo in gpg['repositories']:


### PR DESCRIPTION
This is done via a symlink:
[root@dev ~]# ls -la -la /var/lib/pulp/gpg-export/katello/api/v2/
total 0
drwxr-xr-x. 2 apache apache 25 Jan 11 15:43 .
drwxr-xr-x. 4 apache apache 34 Jan 11 15:43 ..
lrwxrwxrwx. 1 apache apache 15 Jan 11 15:43 repositories -> ../repositories

[root@dev ~]# find -L /var/lib/pulp/gpg-export/katello
/var/lib/pulp/gpg-export/katello
/var/lib/pulp/gpg-export/katello/api
/var/lib/pulp/gpg-export/katello/api/repositories
/var/lib/pulp/gpg-export/katello/api/repositories/334
/var/lib/pulp/gpg-export/katello/api/repositories/334/gpg_key_content
/var/lib/pulp/gpg-export/katello/api/v2
/var/lib/pulp/gpg-export/katello/api/v2/repositories
/var/lib/pulp/gpg-export/katello/api/v2/repositories/334
/var/lib/pulp/gpg-export/katello/api/v2/repositories/334/gpg_key_content